### PR TITLE
Update the image dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bench = false
 
 [dev-dependencies]
 criterion = "0.2.6"
-image = "0.20"
+image = "0.21"
 clap = "2.32"
 time = "0.1"
 


### PR DESCRIPTION
This fixes a vulnerability reported by `cargo audit`.
  https://rustsec.org/advisories/RUSTSEC-2019-0014.html

```
ID:       RUSTSEC-2019-0014
Crate:    image
Version:  0.20.1
Date:     2019-08-21
URL:      https://rustsec.org/advisories/RUSTSEC-2019-0014
Title:    Flaw in interface may drop uninitialized instance of arbitrary types
Solution:  upgrade to >= 0.21.3
Dependency tree: 
image 0.20.1
└── gfwx 0.2.0
```