### PR TITLE
Implement Send and Sync in ImageChunkMut only for types that are also Sync / Send

### DIFF
--- a/src/processing/image.rs
+++ b/src/processing/image.rs
@@ -157,8 +157,8 @@ impl<T> ImageChunkMut<'_, T> {
     }
 }
 
-unsafe impl<T> Send for ImageChunkMut<'_, T> {}
-unsafe impl<T> Sync for ImageChunkMut<'_, T> {}
+unsafe impl<T: Send> Send for ImageChunkMut<'_, T> {}
+unsafe impl<T: Sync> Sync for ImageChunkMut<'_, T> {}
 
 impl<T> Index<(usize, usize)> for ImageChunkMut<'_, T> {
     type Output = T;


### PR DESCRIPTION
This change fixes #7. We were previously implementing the Send and Sync types for all types in ImageChunkMut. This can result in race conditions when using types that are not Send and Sync.